### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ We also added a pty to our browser based editor for those without a terminal.
 
 ## Installation
 
-	pip install flootty
+    pip install Flootty
 
 If you prefer, you can clone the git repo and run:
 


### PR DESCRIPTION
Updates instructions to use correct case of pip package.

◊ pip install flootty
Downloading/unpacking flootty
  Real name of requirement flootty is Flootty
  Could not find any downloads that satisfy the requirement flootty
No distributions at all found for flootty
Storing complete log in /Users/anthonypanozzo/.pip/pip.log

◊ pip install Flootty
Downloading/unpacking Flootty
  Downloading Flootty-1.10.tar.gz
  Running setup.py egg_info for package Flootty

Installing collected packages: Flootty
  Running setup.py install for Flootty

```
Installing flootty script to /usr/local/bin
```

Successfully installed Flootty
Cleaning up...
